### PR TITLE
fix: changed variables to readonly

### DIFF
--- a/gvm-fav
+++ b/gvm-fav
@@ -3,9 +3,9 @@
 . "$GVM_ROOT/scripts/env/gvm"
 . "$GVM_ROOT/scripts/env/use"
 
-command="go test $1 -cover ./..."
+readonly command="go test $1 -cover ./..."
 
-current=$(gvm list | grep '=> ' | sed 's/^.* go/go/')
+readonly current=$(gvm list | grep '=> ' | sed 's/^.* go/go/')
 
 for g in $(gvm list | tail -n +4 | sed 's/^.* go/go/'); do
   gvm_use "${g}"


### PR DESCRIPTION
This PR makes variables to readonly.
There were cases that the variable `current` was changed to empty before reverting to the version at the end of this script.